### PR TITLE
Fix bug with kafka producers connection

### DIFF
--- a/templates/app/kafka.yaml
+++ b/templates/app/kafka.yaml
@@ -96,6 +96,7 @@ objects:
         - name: kafka-data
           persistentVolumeClaim:
             claimName: kafka-data
+        hostname: kafka
 - apiVersion: apps/v1
   kind: Deployment
   metadata:


### PR DESCRIPTION
By default rdkafka using as producer address - podname (not service)
We need to redefine hostname on each of container

<!-- 1. Describe what this PR does and why you think it is needed -->

<!--
2. If this issue fixes an existing issue, please specify in `Fixes #<id>` format
(See https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Tell the bot to mark this with an appropriate label (e.g. bug, enhancement, etc)
e.g. `@miq-bot add-label bug`
-->
